### PR TITLE
Fix children types

### DIFF
--- a/test.js
+++ b/test.js
@@ -64,6 +64,21 @@ test('xastscript', function (t) {
   )
 
   t.deepEqual(
+    x('y', {}, [[[x('a')]], [[[[x('b')]], x('c')]]]),
+    {
+      type: 'element',
+      name: 'y',
+      attributes: {},
+      children: [
+        {type: 'element', name: 'a', attributes: {}, children: []},
+        {type: 'element', name: 'b', attributes: {}, children: []},
+        {type: 'element', name: 'c', attributes: {}, children: []}
+      ]
+    },
+    'should add children in a deeply nested array'
+  )
+
+  t.deepEqual(
     x('y', {}, x('a'), x('b')),
     {
       type: 'element',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,8 @@
-// TypeScript Version: 3.0
+// TypeScript Version: 3.7
 
 import {Attributes, Element, Node} from 'xast'
+
+type Children = string | Node | Children[]
 
 /**
  * Create XML trees in xast.
@@ -8,10 +10,7 @@ import {Attributes, Element, Node} from 'xast'
  * @param name Qualified name. Case sensitive and can contain a namespace prefix (such as rdf:RDF).
  * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
  */
-declare function xastscript(
-  name: string,
-  children?: string | Node | Array<string | Node>
-): Element
+declare function xastscript(name: string, ...children: Children[]): Element
 
 /**
  * Create XML trees in xast.
@@ -23,7 +22,7 @@ declare function xastscript(
 declare function xastscript(
   name: string,
   attributes?: Attributes,
-  children?: string | Node | Array<string | Node>
+  ...children: Children[]
 ): Element
 
 export = xastscript

--- a/types/test.ts
+++ b/types/test.ts
@@ -3,7 +3,9 @@ import x = require('xastscript')
 x('urlset') // $ExpectType Element
 x('urlset', 'string') // $ExpectType Element
 x('urlset', ['string', 'string']) // $ExpectType Element
+x('urlset', x('loc'), 'string') // $ExpectType Element
 x('urlset', x('loc')) // $ExpectType Element
+x('urlset', x('loc'), x('loc')) // $ExpectType Element
 x('urlset', [x('loc'), x('loc')]) // $ExpectType Element
 x('urlset', []) // $ExpectType Element
 
@@ -12,7 +14,9 @@ const xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 x('urlset', {xmlns}) // $ExpectType Element
 x('urlset', {xmlns}, 'string') // $ExpectType Element
 x('urlset', {xmlns}, ['string', 'string']) // $ExpectType Element
+x('urlset', {xmlns}, x('loc'), 'string') // $ExpectType Element
 x('urlset', {xmlns}, x('loc')) // $ExpectType Element
+x('urlset', {xmlns}, x('loc'), x('loc')) // $ExpectType Element
 x('urlset', {xmlns}, [x('loc'), x('loc')]) // $ExpectType Element
 x('urlset', {xmlns}, []) // $ExpectType Element
 


### PR DESCRIPTION
This fixes the following:

- children are accepted as spread arguments, like in the readme examples.
- children may be nested infinitely.

This uses recursive types, which is supported as of TypeScript 3.7.

I was able to determine from the code that arrays of nested children are supported. A test was added to assert this behaviour.