### PR TITLE
Add JSX support in type definition

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -231,15 +231,16 @@ var x = require('xastscript')
 console.log(<music />)
 ```
 
-For [TypeScript][], this can be done by setting `"jsx": "react"` and
-`"jsxFactory": "x"` in the compiler options.  Fragments are not supported in
-TypeScript.  For more details on configuring JSX for TypeScript, see the
+For [TypeScript][], this can be done by setting `"jsx": "react"`,
+`"jsxFactory": "x"`, and `"jsxFragmentFactory": "null"` in the compiler options.
+For more details on configuring JSX for TypeScript, see the
 [TypeScript JSX handbook page][].
 
 TypeScript also lets you configure this in a script:
 
 ```tsx
 /** @jsx x */
+/** @jsxFrag null */
 import * as x from 'xastscript'
 
 console.log(<music />)

--- a/readme.md
+++ b/readme.md
@@ -231,6 +231,19 @@ var x = require('xastscript')
 console.log(<music />)
 ```
 
+For [TypeScript][], this can be done by setting `"jsx": "react"` and
+`"jsxFactory": "x"` in the compiler options.  Fragments are not supported in
+TypeScript.
+
+TypeScript also lets you configure this in a script:
+
+```tsx
+/** @jsx x */
+import * as x from 'xastscript'
+
+console.log(<music />)
+```
+
 ## Security
 
 XML can be a dangerous language: don’t trust user-provided data.
@@ -327,3 +340,5 @@ abide by its terms.
 [babel]: https://github.com/babel/babel
 
 [babel-jsx]: https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-react-jsx
+
+[typescript]: https://www.typescriptlang.org

--- a/readme.md
+++ b/readme.md
@@ -233,7 +233,8 @@ console.log(<music />)
 
 For [TypeScript][], this can be done by setting `"jsx": "react"` and
 `"jsxFactory": "x"` in the compiler options.  Fragments are not supported in
-TypeScript.
+TypeScript.  For more details on configuring JSX for TypeScript, see the
+[TypeScript JSX handbook page][].
 
 TypeScript also lets you configure this in a script:
 
@@ -342,3 +343,5 @@ abide by its terms.
 [babel-jsx]: https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-react-jsx
 
 [typescript]: https://www.typescriptlang.org
+
+[typescript jsx handbook page]: https://www.typescriptlang.org/docs/handbook/jsx.html

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -88,7 +88,7 @@ declare namespace xastscript.JSX {
     /**
      * Only the key matters, not the value.
      */
-    [children]?: any
+    [children]?: never
   }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 3.7
+// TypeScript Version: 4.0
 
 import * as xast from 'xast'
 
@@ -55,7 +55,7 @@ declare namespace xastscript.JSX {
   /**
    * This defines the return value of JSX syntax.
    */
-  type Element = xast.Element
+  type Element = xast.Element | xast.Root
 
   /**
    * This disallows the use of functional components.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,8 @@
 // TypeScript Version: 3.7
 
-import {Attributes, Element, Node} from 'xast'
+import * as xast from 'xast'
 
-type Children = string | Node | Children[]
+type Children = string | xast.Node | Children[]
 
 /**
  * Create XML trees in xast.
@@ -10,7 +10,7 @@ type Children = string | Node | Children[]
  * @param name Qualified name. Case sensitive and can contain a namespace prefix (such as rdf:RDF).
  * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
  */
-declare function xastscript(name: string, ...children: Children[]): Element
+declare function xastscript(name: string, ...children: Children[]): xast.Element
 
 /**
  * Create XML trees in xast.
@@ -21,8 +21,49 @@ declare function xastscript(name: string, ...children: Children[]): Element
  */
 declare function xastscript(
   name: string,
-  attributes?: Attributes,
+  attributes?: xast.Attributes,
   ...children: Children[]
-): Element
+): xast.Element
+
+/**
+ * This namespace allows to use `xastscript` as a JSX implementation.
+ *
+ * This namespace is only used to support the use as JSX. It’s **not** intended for direct usage.
+ */
+declare namespace xastscript.JSX {
+  /**
+   * This defines the return value of JSX syntax.
+   */
+  type Element = xast.Element
+
+  /**
+   * This disallows the use of
+   */
+  type IntrinsicAttributes = never
+
+  /**
+   * This defines the prop types for known elements.
+   *
+   * For `xastscript` this defines any string may be used in combination with `xast` `Attributes`.
+   */
+  interface IntrinsicElements {
+    [key: string]: xast.Attributes & {
+      /**
+       * The prop that matches `ElementChildrenAttribute` key defines the type of JSX children, defines the children type.
+       */
+      ''?: Children
+    }
+  }
+
+  /**
+   * The key of this interface  defines as what prop children are passed.
+   */
+  interface ElementChildrenAttribute {
+    /**
+     * Only the key matters, not the value.
+     */
+    '': never
+  }
+}
 
 export = xastscript

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -58,7 +58,7 @@ declare namespace xastscript.JSX {
   type Element = xast.Element
 
   /**
-   * This disallows the use of
+   * This disallows the use of functional components.
    */
   type IntrinsicAttributes = never
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,7 +41,7 @@ declare function xastscript(
 ): xast.Element
 
 /**
- * This unique symbol is declared to specify they key on which JSX children are passed, without conflicting
+ * This unique symbol is declared to specify the key on which JSX children are passed, without conflicting
  * with the Attributes type.
  */
 declare const children: unique symbol

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,10 +9,7 @@ type Primitive = null | undefined | string | number
 /**
  * Extending Attributes to Support JS Primitive Types
  */
-// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-interface Attributes {
-  [attribute: string]: Primitive
-}
+type Attributes = Record<string, Primitive>
 
 /**
  * Create XML trees in xast.

--- a/types/test-jsx.tsx
+++ b/types/test-jsx.tsx
@@ -1,5 +1,5 @@
 import {Element} from 'xast'
-import x = require('xastscript')
+import * as x from 'xastscript'
 
 const xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 

--- a/types/test-jsx.tsx
+++ b/types/test-jsx.tsx
@@ -1,9 +1,9 @@
-import {Element} from 'xast'
+import {Element, Root} from 'xast'
 import * as x from 'xastscript'
 
 const xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 
-let jsx: Element
+let jsx: Element | Root
 jsx = <urlset />
 jsx = <urlset xmlns={xmlns} />
 jsx = <urlset>string</urlset>
@@ -32,9 +32,13 @@ jsx = (
 )
 jsx = <urlset>{[<loc />, <loc />]}</urlset>
 jsx = <urlset>{[]}</urlset>
+jsx = <></>
 
 jsx = <foo invalid={{}}></foo> // $ExpectError
 jsx = <foo>{{invalid: 'child'}}</foo> // $ExpectError
+
+const element: Element = <foo /> // $ExpectError
+const root: Root = <></> // $ExpectError
 
 declare function Bar(props?: Record<string, unknown>): Element
 const bar = <Bar /> // $ExpectError

--- a/types/test-jsx.tsx
+++ b/types/test-jsx.tsx
@@ -3,44 +3,34 @@ import * as x from 'xastscript'
 
 const xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 
-let jsx
-// $ExpectType Element
+let jsx: Element
 jsx = <urlset />
-// $ExpectType Element
 jsx = <urlset xmlns={xmlns} />
-// $ExpectType Element
 jsx = <urlset>string</urlset>
-// $ExpectType Element
 jsx = <urlset>{['string', 'string']}</urlset>
-// $ExpectType Element
 jsx = (
   <urlset xmlns={xmlns}>
     <child />
   </urlset>
 )
-// $ExpectType Element
 jsx = (
   <urlset>
     <loc />
     string
   </urlset>
 )
-// $ExpectType Element
 jsx = (
   <urlset>
     <loc />
   </urlset>
 )
-// $ExpectType Element
 jsx = (
   <urlset>
     <loc />
     <loc />
   </urlset>
 )
-// $ExpectType Element
 jsx = <urlset>{[<loc />, <loc />]}</urlset>
-// $ExpectType Element
 jsx = <urlset>{[]}</urlset>
 
 jsx = <foo invalid={{}}></foo> // $ExpectError

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,4 +1,4 @@
-import x = require('xastscript')
+import * as x from 'xastscript'
 
 x('urlset') // $ExpectType Element
 x('urlset', 'string') // $ExpectType Element

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -1,3 +1,6 @@
+/** @jsx x */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {Attributes, Element} from 'xast'
 import x = require('xastscript')
 
 x('urlset') // $ExpectType Element
@@ -20,6 +23,41 @@ x('urlset', {xmlns}, x('loc'), x('loc')) // $ExpectType Element
 x('urlset', {xmlns}, [x('loc'), x('loc')]) // $ExpectType Element
 x('urlset', {xmlns}, []) // $ExpectType Element
 
+// $ExpectType Element
+const jsx0 = <urlset />
+// $ExpectType Element
+const jsx1 = <urlset xmlns={xmlns} />
+// $ExpectType Element
+const jsx2 = <urlset>string</urlset>
+// $ExpectType Element
+const jsx3 = <urlset>{['string', 'string']}</urlset>
+// $ExpectType Element
+const jsx4 = (
+  <urlset>
+    <loc />
+    string
+  </urlset>
+)
+// $ExpectType Element
+const jsx5 = (
+  <urlset>
+    <loc />
+  </urlset>
+)
+// $ExpectType Element
+const jsx6 = (
+  <urlset>
+    <loc />
+    <loc />
+  </urlset>
+)
+// $ExpectType Element
+const jsx7 = <urlset>{[<loc />, <loc />]}</urlset>
+// $ExpectType Element
+const jsx8 = <urlset>{[]}</urlset>
+
+declare function Bar(props?: Attributes): Element
+const bar = <Bar /> // $ExpectError
 x() // $ExpectError
 x(false) // $ExpectError
 x('urlset', x('loc'), {xmlns}) // $ExpectError

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "jsx": "react",
     "lib": ["es2015"],
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "jsx": "react",
     "jsxFactory": "x",
+    "jsxFragmentFactory": "null",
     "lib": ["es2015"],
     "noImplicitAny": true,
     "noImplicitThis": true,


### PR DESCRIPTION
This adds TypeScript support to use `xastscript` as JSX. This is just an idea. It’s definitely open for discussion. :)

The interface already supports JSX legacy mode, meaning this was already supported, except for types.

I don’t know if this was intended. Basically any function that accepts a tag name as first argument, props as second argument, and children as spread arguments, can be considered a JSX compatible function. I figured for `xastscript` it makes sense, because it’s for working with XML.

Some quirks:

- JSX elements starting with upper case will be converted to variables, so XML tags starting with lower case can be used directly.
- TypeScript doesn’t support namespaces in JSX.
- Users may request support for the new JSX mode at some point.

