### PR TITLE
types: add support for null/fragment type in typescript definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 // TypeScript Version: 3.7
 
-import {Element, Node} from 'xast'
+import {Element, Node, Root} from 'xast'
 
 type Children = string | Node | number | Children[]
 
@@ -17,8 +17,26 @@ type Attributes = Record<string, Primitive>
  * @param name Qualified name. Case sensitive and can contain a namespace prefix (such as rdf:RDF).
  * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
  */
+declare function xastscript(name: string, ...children: Children[]): Element
+
+/**
+ * Create XML trees in xast.
+ *
+ * @param name Qualified name. Case sensitive and can contain a namespace prefix (such as rdf:RDF).
+ * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
+ */
+declare function xastscript(name: null, ...children: Children[]): Root
+
+/**
+ * Create XML trees in xast.
+ *
+ * @param name Qualified name. Case sensitive and can contain a namespace prefix (such as rdf:RDF).
+ * @param attributes Map of attributes. Nullish (null or undefined) or NaN values are ignored, other values are turned to strings.
+ * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
+ */
 declare function xastscript(
-  name: string | null,
+  name: string,
+  attributes?: Attributes,
   ...children: Children[]
 ): Element
 
@@ -30,9 +48,9 @@ declare function xastscript(
  * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
  */
 declare function xastscript(
-  name: string | null,
+  name: null,
   attributes?: Attributes,
   ...children: Children[]
-): Element
+): Root
 
 export = xastscript

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,17 +40,4 @@ declare function xastscript(
   ...children: Children[]
 ): Element
 
-/**
- * Create XML trees in xast.
- *
- * @param name Qualified name. Case sensitive and can contain a namespace prefix (such as rdf:RDF).
- * @param attributes Map of attributes. Nullish (null or undefined) or NaN values are ignored, other values are turned to strings.
- * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
- */
-declare function xastscript(
-  name: null,
-  attributes?: Attributes,
-  ...children: Children[]
-): Root
-
 export = xastscript

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,10 @@ type Attributes = Record<string, Primitive>
  * @param name Qualified name. Case sensitive and can contain a namespace prefix (such as rdf:RDF).
  * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
  */
-declare function xastscript(name: string, ...children: Children[]): Element
+declare function xastscript(
+  name: string | null,
+  ...children: Children[]
+): Element
 
 /**
  * Create XML trees in xast.
@@ -27,7 +30,7 @@ declare function xastscript(name: string, ...children: Children[]): Element
  * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
  */
 declare function xastscript(
-  name: string,
+  name: string | null,
   attributes?: Attributes,
   ...children: Children[]
 ): Element

--- a/types/test.ts
+++ b/types/test.ts
@@ -9,10 +9,10 @@ x('urlset', x('loc')) // $ExpectType Element
 x('urlset', x('loc'), x('loc')) // $ExpectType Element
 x('urlset', [x('loc'), x('loc')]) // $ExpectType Element
 x('urlset', []) // $ExpectType Element
-x(null) // $ExpectType Element
-x(null, 'string') // $ExpectType Element
-x(null, 1) // $ExpectType Element
-x(null, []) // $ExpectType Element
+x(null) // $ExpectType Root
+x(null, 'string') // $ExpectType Root
+x(null, 1) // $ExpectType Root
+x(null, []) // $ExpectType Root
 
 const xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 
@@ -25,10 +25,10 @@ x('urlset', {xmlns}, x('loc')) // $ExpectType Element
 x('urlset', {xmlns}, x('loc'), x('loc')) // $ExpectType Element
 x('urlset', {xmlns}, [x('loc'), x('loc')]) // $ExpectType Element
 x('urlset', {xmlns}, []) // $ExpectType Element
-x(null, {xmlns}) // $ExpectType Element
-x(null, {xmlns}, 'string') // $ExpectType Element
-x(null, {xmlns}, 1) // $ExpectType Element
-x(null, {xmlns}, []) // $ExpectType Element
+x(null, {xmlns}) // $ExpectType Root
+x(null, {xmlns}, 'string') // $ExpectType Root
+x(null, {xmlns}, 1) // $ExpectType Root
+x(null, {xmlns}, []) // $ExpectType Root
 
 const xmlNumberAttribute = 100
 x('urlset', {xmlNumberAttribute}, 'string') // $ExpectType Element

--- a/types/test.ts
+++ b/types/test.ts
@@ -25,10 +25,6 @@ x('urlset', {xmlns}, x('loc')) // $ExpectType Element
 x('urlset', {xmlns}, x('loc'), x('loc')) // $ExpectType Element
 x('urlset', {xmlns}, [x('loc'), x('loc')]) // $ExpectType Element
 x('urlset', {xmlns}, []) // $ExpectType Element
-x(null, {xmlns}) // $ExpectType Root
-x(null, {xmlns}, 'string') // $ExpectType Root
-x(null, {xmlns}, 1) // $ExpectType Root
-x(null, {xmlns}, []) // $ExpectType Root
 
 const xmlNumberAttribute = 100
 x('urlset', {xmlNumberAttribute}, 'string') // $ExpectType Element
@@ -39,3 +35,4 @@ x('urlset', {xmlNumberAttribute}, []) // $ExpectType Element
 x() // $ExpectError
 x(false) // $ExpectError
 x('urlset', x('loc'), {xmlns}) // $ExpectError
+x(null, {xmlns}) // $ExpectError

--- a/types/test.ts
+++ b/types/test.ts
@@ -2,12 +2,17 @@ import x = require('xastscript')
 
 x('urlset') // $ExpectType Element
 x('urlset', 'string') // $ExpectType Element
+x('urlset', 1) // $ExpectType Element
 x('urlset', ['string', 'string']) // $ExpectType Element
 x('urlset', x('loc'), 'string') // $ExpectType Element
 x('urlset', x('loc')) // $ExpectType Element
 x('urlset', x('loc'), x('loc')) // $ExpectType Element
 x('urlset', [x('loc'), x('loc')]) // $ExpectType Element
 x('urlset', []) // $ExpectType Element
+x(null) // $ExpectType Element
+x(null, 'string') // $ExpectType Element
+x(null, 1) // $ExpectType Element
+x(null, []) // $ExpectType Element
 
 const xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 
@@ -20,6 +25,10 @@ x('urlset', {xmlns}, x('loc')) // $ExpectType Element
 x('urlset', {xmlns}, x('loc'), x('loc')) // $ExpectType Element
 x('urlset', {xmlns}, [x('loc'), x('loc')]) // $ExpectType Element
 x('urlset', {xmlns}, []) // $ExpectType Element
+x(null, {xmlns}) // $ExpectType Element
+x(null, {xmlns}, 'string') // $ExpectType Element
+x(null, {xmlns}, 1) // $ExpectType Element
+x(null, {xmlns}, []) // $ExpectType Element
 
 const xmlNumberAttribute = 100
 x('urlset', {xmlNumberAttribute}, 'string') // $ExpectType Element


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/syntax-tree/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/syntax-tree/.github/blob/main/support.md
https://github.com/syntax-tree/.github/blob/main/contributing.md
-->

builds off #4 