### PR TITLE
types: support xastscript used as JSX in typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 // TypeScript Version: 3.7
 
-import {Element, Node, Root} from 'xast'
+import {Element as XastElement, Node, Root} from 'xast'
 
 type Children = string | Node | number | Children[]
 
@@ -17,7 +17,7 @@ type Attributes = Record<string, Primitive>
  * @param name Qualified name. Case sensitive and can contain a namespace prefix (such as rdf:RDF).
  * @param children (Lists of) child nodes. When strings are encountered, they are mapped to Text nodes.
  */
-declare function xastscript(name: string, ...children: Children[]): Element
+declare function xastscript(name: string, ...children: Children[]): XastElement
 
 /**
  * Create XML trees in xast.
@@ -38,6 +38,35 @@ declare function xastscript(
   name: string,
   attributes?: Attributes,
   ...children: Children[]
-): Element
+): XastElement
+
+declare namespace xastscript.JSX {
+  /**
+   * This defines the return value of JSX syntax.
+   */
+  type Element = XastElement
+
+  /**
+   * This disallows the use of intrinsics
+   */
+  type IntrinsicAttributes = never
+
+  /**
+   * This defines the prop types for known elements.
+   *
+   * For `xastscript` this defines any string may be used in combination with `xast` `Attributes`.
+   */
+  type IntrinsicElements = Record<string, Attributes>
+
+  /**
+   * The key of this interface  defines as what prop children are passed.
+   */
+  interface ElementChildrenAttribute {
+    /**
+     * Only the key matters, not the value.
+     */
+    '': never
+  }
+}
 
 export = xastscript

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,5 +1,8 @@
 import x = require('xastscript')
 
+const xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+const xmlNumberAttribute = 100
+
 x('urlset') // $ExpectType Element
 x('urlset', 'string') // $ExpectType Element
 x('urlset', 1) // $ExpectType Element
@@ -14,8 +17,6 @@ x(null, 'string') // $ExpectType Root
 x(null, 1) // $ExpectType Root
 x(null, []) // $ExpectType Root
 
-const xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
-
 x('urlset', {xmlns}) // $ExpectType Element
 x('urlset', {xmlns}, 'string') // $ExpectType Element
 x('urlset', {xmlns}, ['string', 'string']) // $ExpectType Element
@@ -26,7 +27,6 @@ x('urlset', {xmlns}, x('loc'), x('loc')) // $ExpectType Element
 x('urlset', {xmlns}, [x('loc'), x('loc')]) // $ExpectType Element
 x('urlset', {xmlns}, []) // $ExpectType Element
 
-const xmlNumberAttribute = 100
 x('urlset', {xmlNumberAttribute}, 'string') // $ExpectType Element
 x('urlset', {xmlNumberAttribute}, 100) // $ExpectType Element
 x('urlset', {xmlNumberAttribute}, x('loc'), 100) // $ExpectType Element

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -1,0 +1,41 @@
+/** @jsx x */
+import x = require('xastscript')
+
+const xmlns = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+const xmlNumberAttribute = 100
+
+const t0 = <urlset /> // $ExpectType Element
+const t1 = <urlset xmlns={xmlns} /> // $ExpectType Element
+const t2 = <urlset xmlNumberAttribute={xmlNumberAttribute} /> // $ExpectType Element
+const t3 = <urlset>string</urlset> // $ExpectType Element
+// $ExpectType Element
+const t4 = (
+  <urlset>
+    <text />
+  </urlset>
+)
+// $ExpectType Element
+const t5 = <urlset>text</urlset>
+// $ExpectType Element
+const t6 = (
+  <urlset>
+    <text />
+    <text />
+  </urlset>
+)
+// $ExpectType Element
+const t7 = (
+  <urlset>
+    test
+    <text />
+  </urlset>
+)
+// $ExpectType Element
+const t8 = (
+  <urlset>
+    {['a', 'b'].map((value) => (
+      <text>{value}</text>
+    ))}
+  </urlset>
+)
+const t9 = <urlset xmlns /> // $ExpectError

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "lib": ["es2015"],
+    "jsx": "react",
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Follow up to #3, I'd be okay with either PR moving forward, but wanted to avoid committing over @remcohaszing's work.