### PR TITLE
Make type definitions work for classic runtime

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,11 @@
  * @typedef {string|number|null|undefined} XPrimitiveChild
  * @typedef {Array.<Node|XPrimitiveChild>} XArrayChild
  * @typedef {Node|XPrimitiveChild|XArrayChild} XChild
+ * @typedef {import('./jsx-classic').Element} x.JSX.Element
+ * @typedef {import('./jsx-classic').IntrinsicAttributes} x.JSX.IntrinsicAttributes
+ * @typedef {import('./jsx-classic').IntrinsicElements} x.JSX.IntrinsicElements
+ * @typedef {import('./jsx-classic').ElementChildrenAttribute} x.JSX.ElementChildrenAttribute
  */
-
-export * from './jsx-classic.js'
 
 /**
  * Create XML trees in xast.

--- a/lib/jsx-classic.d.ts
+++ b/lib/jsx-classic.d.ts
@@ -1,4 +1,4 @@
-import {XAttributes, XChild, XResult, x} from './index.js'
+import {XAttributes, XChild, XResult} from './index.js'
 
 /**
  * This unique symbol is declared to specify the key on which JSX children are passed, without conflicting
@@ -6,43 +6,41 @@ import {XAttributes, XChild, XResult, x} from './index.js'
  */
 declare const children: unique symbol
 
-export namespace JSX {
-  /**
-   * This defines the return value of JSX syntax.
-   */
-  type Element = XResult
+/**
+ * This defines the return value of JSX syntax.
+ */
+export type Element = XResult
 
-  /**
-   * This disallows the use of functional components.
-   */
-  type IntrinsicAttributes = never
+/**
+ * This disallows the use of functional components.
+ */
+export type IntrinsicAttributes = never
 
-  /**
-   * This defines the prop types for known elements.
-   *
-   * For `xastscript` this defines any string may be used in combination with `xast` `Attributes`.
-   *
-   * This **must** be an interface.
-   */
-  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-  interface IntrinsicElements {
-    [name: string]:
-      | XAttributes
-      | {
-          /**
-           * The prop that matches `ElementChildrenAttribute` key defines the type of JSX children, defines the children type.
-           */
-          [children]?: XChild
-        }
-  }
+/**
+ * This defines the prop types for known elements.
+ *
+ * For `xastscript` this defines any string may be used in combination with `xast` `Attributes`.
+ *
+ * This **must** be an interface.
+ */
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+export interface IntrinsicElements {
+  [name: string]:
+    | XAttributes
+    | {
+        /**
+         * The prop that matches `ElementChildrenAttribute` key defines the type of JSX children, defines the children type.
+         */
+        [children]?: XChild
+      }
+}
 
+/**
+ * The key of this interface defines as what prop children are passed.
+ */
+export interface ElementChildrenAttribute {
   /**
-   * The key of this interface defines as what prop children are passed.
+   * Only the key matters, not the value.
    */
-  interface ElementChildrenAttribute {
-    /**
-     * Only the key matters, not the value.
-     */
-    [children]?: never
-  }
+  [children]?: never
 }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Nesting properties in a `@typedef` type annotation will generate a namespace, which can be used to generate the required JSX namespace.