### PR TITLE
Fix types of automatic and classic runtimes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,11 @@
  * @typedef {string|number|null|undefined} XPrimitiveChild
  * @typedef {Array.<Node|XPrimitiveChild>} XArrayChild
  * @typedef {Node|XPrimitiveChild|XArrayChild} XChild
+ * @typedef {import('./jsx-classic').Element} x.JSX.Element
+ * @typedef {import('./jsx-classic').IntrinsicAttributes} x.JSX.IntrinsicAttributes
+ * @typedef {import('./jsx-classic').IntrinsicElements} x.JSX.IntrinsicElements
+ * @typedef {import('./jsx-classic').ElementChildrenAttribute} x.JSX.ElementChildrenAttribute
  */
-
-export * from './jsx-classic.js'
 
 /**
  * Create XML trees in xast.

--- a/lib/jsx-automatic.d.ts
+++ b/lib/jsx-automatic.d.ts
@@ -1,11 +1,5 @@
 import {XAttributes, XChild, XResult} from './index.js'
 
-/**
- * This unique symbol is declared to specify the key on which JSX children are passed, without conflicting
- * with the Attributes type.
- */
-declare const children: unique symbol
-
 export namespace JSX {
   /**
    * This defines the return value of JSX syntax.
@@ -32,7 +26,7 @@ export namespace JSX {
           /**
            * The prop that matches `ElementChildrenAttribute` key defines the type of JSX children, defines the children type.
            */
-          [children]?: XChild
+          children?: XChild
         }
   }
 
@@ -43,6 +37,6 @@ export namespace JSX {
     /**
      * Only the key matters, not the value.
      */
-    [children]?: never
+    children?: never
   }
 }

--- a/lib/jsx-classic.d.ts
+++ b/lib/jsx-classic.d.ts
@@ -1,4 +1,4 @@
-import {XAttributes, XChild, XResult, x} from './index.js'
+import {XAttributes, XChild, XResult} from './index.js'
 
 /**
  * This unique symbol is declared to specify the key on which JSX children are passed, without conflicting
@@ -6,43 +6,41 @@ import {XAttributes, XChild, XResult, x} from './index.js'
  */
 declare const children: unique symbol
 
-export namespace JSX {
-  /**
-   * This defines the return value of JSX syntax.
-   */
-  type Element = XResult
+/**
+ * This defines the return value of JSX syntax.
+ */
+export type Element = XResult
 
-  /**
-   * This disallows the use of functional components.
-   */
-  type IntrinsicAttributes = never
+/**
+ * This disallows the use of functional components.
+ */
+export type IntrinsicAttributes = never
 
-  /**
-   * This defines the prop types for known elements.
-   *
-   * For `xastscript` this defines any string may be used in combination with `xast` `Attributes`.
-   *
-   * This **must** be an interface.
-   */
-  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-  interface IntrinsicElements {
-    [name: string]:
-      | XAttributes
-      | {
-          /**
-           * The prop that matches `ElementChildrenAttribute` key defines the type of JSX children, defines the children type.
-           */
-          [children]?: XChild
-        }
-  }
+/**
+ * This defines the prop types for known elements.
+ *
+ * For `xastscript` this defines any string may be used in combination with `xast` `Attributes`.
+ *
+ * This **must** be an interface.
+ */
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+export interface IntrinsicElements {
+  [name: string]:
+    | XAttributes
+    | {
+        /**
+         * The prop that matches `ElementChildrenAttribute` key defines the type of JSX children, defines the children type.
+         */
+        [children]?: XChild
+      }
+}
 
+/**
+ * The key of this interface defines as what prop children are passed.
+ */
+export interface ElementChildrenAttribute {
   /**
-   * The key of this interface defines as what prop children are passed.
+   * Only the key matters, not the value.
    */
-  interface ElementChildrenAttribute {
-    /**
-     * Only the key matters, not the value.
-     */
-    [children]?: never
-  }
+  [children]?: never
 }

--- a/test-d/automatic.tsx
+++ b/test-d/automatic.tsx
@@ -50,6 +50,7 @@ expectError(<a invalid={[1]} />)
 expectError(<a>{{invalid: 'child'}}</a>)
 
 // This is where the automatic runtime differs from the classic runtime.
+// The automatic runtime the children prop to define JSX children, whereas it’s used as an attribute in the classic runtime.
 expectType<Result>(<a children={<b />} />)
 
 declare function Bar(props?: Record<string, unknown>): Element

--- a/test-d/automatic.tsx
+++ b/test-d/automatic.tsx
@@ -49,5 +49,8 @@ expectError(<a invalid={{}} />)
 expectError(<a invalid={[1]} />)
 expectError(<a>{{invalid: 'child'}}</a>)
 
+// This is where the automatic runtime differs from the classic runtime.
+expectType<Result>(<a children={<b />} />)
+
 declare function Bar(props?: Record<string, unknown>): Element
 expectError(<Bar />)

--- a/test-d/classic.tsx
+++ b/test-d/classic.tsx
@@ -39,6 +39,8 @@ expectError(<a invalid={[1]} />)
 expectError(<a>{{invalid: 'child'}}</a>)
 
 // This is where the classic runtime differs from the automatic runtime.
+// The automatic runtime the children prop to define JSX children, whereas it’s
+// used as an attribute in the classic runtime.
 expectError(<a children={<b />} />)
 
 declare function Bar(props?: Record<string, unknown>): Element

--- a/test-d/classic.tsx
+++ b/test-d/classic.tsx
@@ -6,7 +6,6 @@ import {x} from '../index.js'
 
 type Result = Element | Root
 
-// To do: fix classic types.
 expectType<Result>(<></>)
 expectType<Result>(<a />)
 expectType<Result>(<a b="c" />)

--- a/test-d/classic.tsx
+++ b/test-d/classic.tsx
@@ -40,6 +40,9 @@ expectError(<a invalid={{}} />)
 expectError(<a invalid={[1]} />)
 expectError(<a>{{invalid: 'child'}}</a>)
 
+// This is where the classic runtime differs from the automatic runtime.
+expectError(<a children={<b />} />)
+
 declare function Bar(props?: Record<string, unknown>): Element
 expectError(<Bar />)
 

--- a/test-d/classic.tsx
+++ b/test-d/classic.tsx
@@ -7,7 +7,6 @@ import {x} from '../index.js'
 type Result = Element | Root
 
 // To do: fix classic types.
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 expectType<Result>(<></>)
 expectType<Result>(<a />)
 expectType<Result>(<a b="c" />)
@@ -45,5 +44,3 @@ expectError(<a children={<b />} />)
 
 declare function Bar(props?: Record<string, unknown>): Element
 expectError(<Bar />)
-
-/* eslint-enable @typescript-eslint/no-unsafe-argument */


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This specifies the children prop must be a valid xast child for the automatic runtime, but a valid attribute for the classic runtime.
