### PR TITLE
Fix missing `jsx-runtime` in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   "files": [
     "lib/",
     "index.d.ts",
-    "index.js"
+    "index.js",
+    "jsx-runtime.d.ts",
+    "jsx-runtime.js"
   ],
   "exports": {
     ".": "./index.js",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`jsx-runtime.js` is part of the exports, but it’s not included in the files to publish.

<!--do not edit: pr-->
