### PR TITLE
Add extensions to local imports of files in types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,10 +10,10 @@
  * @typedef {string|number|null|undefined} XPrimitiveChild
  * @typedef {Array<Node|XPrimitiveChild>} XArrayChild
  * @typedef {Node|XPrimitiveChild|XArrayChild} XChild
- * @typedef {import('./jsx-classic').Element} x.JSX.Element
- * @typedef {import('./jsx-classic').IntrinsicAttributes} x.JSX.IntrinsicAttributes
- * @typedef {import('./jsx-classic').IntrinsicElements} x.JSX.IntrinsicElements
- * @typedef {import('./jsx-classic').ElementChildrenAttribute} x.JSX.ElementChildrenAttribute
+ * @typedef {import('./jsx-classic.js').Element} x.JSX.Element
+ * @typedef {import('./jsx-classic.js').IntrinsicAttributes} x.JSX.IntrinsicAttributes
+ * @typedef {import('./jsx-classic.js').IntrinsicElements} x.JSX.IntrinsicElements
+ * @typedef {import('./jsx-classic.js').ElementChildrenAttribute} x.JSX.ElementChildrenAttribute
  */
 
 /**


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This is needed for the `node16` module resolution.

The use of `"module": "node16"` in this project’s `tsconfig.json`  has been withheld because of davidbonnet/astring#646.

<!--do not edit: pr-->
